### PR TITLE
Make class versatile with clsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ Alternativley you can use a style object like so:
 <Body {style} />
 ```
 
+For Class, you can pass a combination of string, object, and array of both of these. Literally anything that can be passed to [class](https://github.com/lukeed/clsx).
+
+```svelte
+<script>
+  import { classList } from 'svelte-body';
+
+  let isBlue = true;
+</script>
+
+<Body class="red green blue" />
+<Body class={{ red: true, blue: isBlue }} />
+<Body class={['red', isBlue && 'blue']} />
+<Body class={[ 'red', { blue: isBlue } ]} />
+```
+
 # Actions
 
 There are also [svelte actions](https://svelte.dev/docs#use_action) that can be used on `<svelte:body />`:
@@ -59,7 +74,10 @@ There are also [svelte actions](https://svelte.dev/docs#use_action) that can be 
         import { classList } from 'svelte-body';
     </script>
 
-    <svelte:body use:classList={"red green blue"}>
+    <svelte:body use:classList={"red green blue"} />
+    <svelte:body use:classList={{ red: true, blue: isBlue }} />
+    <svelte:body use:classList={['red', isBlue && 'blue']} />
+    <svelte:body use:classList={[ 'red', { blue: isBlue } ]} />
     ```
 
 -   `style`
@@ -69,7 +87,7 @@ There are also [svelte actions](https://svelte.dev/docs#use_action) that can be 
         import { style } from 'svelte-body';
     </script>
 
-    <svelte:body use:style={"background-color: blue;"}>
+    <svelte:body use:style={"background-color: blue;"} />
     ```
 
     It can also take an object:

--- a/dev/src/App.svelte
+++ b/dev/src/App.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
     // import logo from './assets/svelte.png';
     import Counter from './lib/Counter.svelte';
-    import { style } from 'svelte-body';
+    import { style, classList } from '../../dist';
 </script>
 
-<svelte:body use:style={{ background: 'blue', '--cool-css-prop': 'nlue' }} />
+<svelte:body
+    use:style={{ color: 'blue', '--cool-css-prop': 'nlue' }}
+    use:classList={['hello', { blue: true }]} />
 
 <main>
     <!-- <img src={logo} alt="Svelte Logo" /> -->

--- a/dev/src/App.svelte
+++ b/dev/src/App.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     // import logo from './assets/svelte.png';
     import Counter from './lib/Counter.svelte';
-    import { style, classList } from '../../dist';
+    import { style, classList } from 'svelte-body';
 </script>
 
 <svelte:body

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
+        "clsx": "^1.1.1",
         "csstype": "^3.0.10"
       },
       "devDependencies": {
@@ -171,6 +172,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -1346,6 +1355,11 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
+    },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
     "color-convert": {
       "version": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^21.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
+    "clsx": "^1.1.1",
     "npm-run-all": "^4.1.5",
     "prettier-plugin-svelte": "^2.4.0",
     "rollup": "^2.32.0",

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,7 +1,8 @@
 import { writable, get } from 'svelte/store';
+import clsx from 'clsx';
 
 export const classList = (node, classString = '') => {
-    const classes = writable(classString.split(' ').filter(Boolean));
+    const classes = writable(clsx(classString).split(' ').filter(Boolean));
 
     // When the classes store changes add the new classes
     const unsubscribe = classes.subscribe((list) => {
@@ -32,8 +33,14 @@ export const style = (node, styleData = {}) => {
         if (typeof styleData == 'string') pseudoElement.style = styleData;
 
         if (typeof styleData == 'object')
-            for (const [property, value] of Object.entries(styleData))
-                pseudoElement.style.setProperty(property, value);
+            for (const [property, value] of Object.entries(styleData)) {
+                // Do a setProperty in case it's a CSS variable
+                if (property.startsWith('--')) {
+                    pseudoElement.style.setProperty(property, value);
+                } else {
+                    pseudoElement.style[property] = value;
+                }
+            }
 
         // Combine body's existing styles with computed ones
         node.style = `

--- a/types/Body.svelte.d.ts
+++ b/types/Body.svelte.d.ts
@@ -1,17 +1,46 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from 'svelte';
 import { Properties } from 'csstype';
+import { ClassValue } from './actions.d';
 
 export interface BodyProps {
     /**
-     * A string of styles (style="" on a HTML element)
+     * Svelte action to add style on `body`. style can either be a string or an object.
+     *
+     * @example
+     *
+     *```svelte
+     * <script>
+     *   import { style } from 'svelte-body';
+     * </script>
+     *
+     * <svelte:body use:style={"background-color: blue;"}>
+     * <svelte:body use:style={{ backgroundColor: 'blue' }}>
+     *```
      */
     style?: string | Properties;
 
     /**
-     * A string of class names (class="" on a HTML element)
+     * Svelte action to change class on `body`
+     *
+     * You can pass a string or object, or an array of combination of these. Literally anything that [clsx](https://github.com/lukeed/clsx) accepts.
+     *
+     * @example
+     *
+     *```svelte
+     * <script>
+     *   import { classList } from 'svelte-body';
+     *
+     *   let isBlue = true;
+     * </script>
+     *
+     * <svelte:body use:classList={"red green blue"}>
+     * <svelte:body use:classList={{ red: true, blue: isBlue }}>
+     * <svelte:body use:classList={['red', isBlue && 'blue']}>
+     * <svelte:body use:classList={[ 'red', { blue: isBlue } ]}>
+     *```
      */
-    class?: string;
+    class?: ClassValue;
 }
 
 export default class Body extends SvelteComponentTyped<BodyProps, {}, {}> {}

--- a/types/actions.d.ts
+++ b/types/actions.d.ts
@@ -1,6 +1,22 @@
 /// <reference types="svelte" />
 import { Properties } from 'csstype';
 
+// Copied from `clsx` to remove it from dependencies
+export type ClassValue =
+    | ClassArray
+    | ClassDictionary
+    | string
+    | number
+    | null
+    | boolean
+    | undefined;
+
+export interface ClassDictionary {
+    [id: string]: any;
+}
+
+export interface ClassArray extends Array<ClassValue> {}
+
 declare module 'csstype' {
     interface Properties {
         // Add a CSS Custom Property
@@ -10,6 +26,8 @@ declare module 'csstype' {
 
 /**
  * Svelte action to change class on `body`
+ *
+ * You can pass a string or object, or an array of combination of these. Literally anything that [clsx](https://github.com/lukeed/clsx) accepts.
  *
  * @example
  *
@@ -21,12 +39,46 @@ declare module 'csstype' {
  * <svelte:body use:classList={"red green blue"}>
  *```
  *
+ * @example
+ *
+ *```svelte
+ * <script>
+ *   import { classList } from 'svelte-body';
+ *
+ *   let isBlue = true;
+ * </script>
+ *
+ * <svelte:body use:classList={{ red: true, blue: isBlue }}>
+ *```
+ *
+ * @example
+ *
+ *```svelte
+ * <script>
+ *   import { classList } from 'svelte-body';
+ *
+ *   let isBlue = true;
+ * </script>
+ *
+ * <svelte:body use:classList={['red', isBlue && 'blue']}>
+ *```
+ *
+ * @example
+ *
+ * ```svelte
+ * <script>
+ *  import { classList } from 'svelte-body';
+ * </script>
+ *
+ * <svelte:body use:classList={[ 'red', { blue: isBlue } ]}>
+ *```
+ *
  * @param {HTMLElement} node
  * @param classString
  */
 export function classList(
     node: HTMLElement,
-    classString: string,
+    classString: ClassValue,
 ): { update: () => void; destroy: () => void };
 
 /**

--- a/types/actions.d.ts
+++ b/types/actions.d.ts
@@ -34,42 +34,13 @@ declare module 'csstype' {
  *```svelte
  * <script>
  *   import { classList } from 'svelte-body';
+ *
+ *   let isBlue = true;
  * </script>
  *
  * <svelte:body use:classList={"red green blue"}>
- *```
- *
- * @example
- *
- *```svelte
- * <script>
- *   import { classList } from 'svelte-body';
- *
- *   let isBlue = true;
- * </script>
- *
  * <svelte:body use:classList={{ red: true, blue: isBlue }}>
- *```
- *
- * @example
- *
- *```svelte
- * <script>
- *   import { classList } from 'svelte-body';
- *
- *   let isBlue = true;
- * </script>
- *
  * <svelte:body use:classList={['red', isBlue && 'blue']}>
- *```
- *
- * @example
- *
- * ```svelte
- * <script>
- *  import { classList } from 'svelte-body';
- * </script>
- *
  * <svelte:body use:classList={[ 'red', { blue: isBlue } ]}>
  *```
  *
@@ -92,15 +63,6 @@ export function classList(
  * </script>
  *
  * <svelte:body use:style={"background-color: blue;"}>
- *```
- *
- * @example
- *
- *```svelte
- * <script>
- *   import { style } from 'svelte-body';
- * </script>
- *
  * <svelte:body use:style={{ backgroundColor: 'blue' }}>
  *```
  *

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,2 +1,2 @@
 export { default as Body } from './Body.svelte';
-export * from './actions.d';
+export { classList, style } from './actions.d';


### PR DESCRIPTION
- Add clsx to make `class` prop versatile
- Fix the issue where style object containing camel case properties doesn't work